### PR TITLE
Make "kernel fetching" configurable and client-driven

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,6 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.0.1
+
 <!-- <END NEW CHANGELOG ENTRY> -->

--- a/README.md
+++ b/README.md
@@ -3,3 +3,27 @@
 A server extension that synchronizes all managers in a running Jupyter Server.
 
 This is particularly useful for Jupyter Servers running remote kernels and contents.
+
+## Basic usage
+
+Install and enable the extension:
+
+```
+pip install jupyter_server_synchronizer
+
+jupyter server extension enable jupyter_server_synchronizer
+```
+
+When you start a Jupyter Server, it synchronize all managers before the Web application is started.
+
+```
+jupyter server
+```
+
+To synchronize periodically, enable the auto-synchronizing feature using the `autosync` config option. For example,
+
+```
+jupyter server --SynchronizerExtension.autosync=True
+```
+
+Otherwise, you can trigger the synchronization making a `POST` request to the `/api/sync` endpoint.

--- a/jupyter_server_synchronizer/handlers.py
+++ b/jupyter_server_synchronizer/handlers.py
@@ -1,0 +1,17 @@
+from jupyter_server.base.handlers import APIHandler
+from jupyter_server.extension.handler import ExtensionHandlerMixin
+from tornado.web import HTTPError
+
+
+class SynchronizerHandler(ExtensionHandlerMixin, APIHandler):
+    async def post(self):
+        """Trigger the synchronizer"""
+        try:
+            await self.extensionapp.sync_managers()
+        except Exception as err:
+            raise HTTPError(500, log_message=str(err))
+
+
+handlers = [
+    (r"/api/sync", SynchronizerHandler),
+]

--- a/jupyter_server_synchronizer/kernel_records.py
+++ b/jupyter_server_synchronizer/kernel_records.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, fields
 from typing import Union
 
+from jupyter_client.manager import KernelManager
+
 
 class KernelRecordConflict(Exception):
     """An exception raised when trying to merge two
@@ -26,6 +28,17 @@ class KernelRecord:
     alive: Union[None, bool] = None
     recorded: Union[None, bool] = None
     managed: Union[None, bool] = None
+
+    @classmethod
+    def from_manager(cls, manager: KernelManager) -> "KernelRecord":
+        """Create a kernel from a KernelManager."""
+        record = cls()
+        # Look for the record fields as attributes the kernel manager
+        # and make the values match.
+        for field in cls.get_identifier_fields():
+            setattr(record, field, getattr(manager, field, None))
+        record.managed = True
+        return record
 
     @classmethod
     def get_identifier_fields(cls):

--- a/jupyter_server_synchronizer/traits.py
+++ b/jupyter_server_synchronizer/traits.py
@@ -1,0 +1,13 @@
+import inspect
+
+from traitlets import TraitType
+
+
+class Awaitable(TraitType):
+
+    info_text = "an awaitable"
+
+    def validate(self, obj, value):
+        if not inspect.iscoroutinefunction(value) and not inspect.isawaitable(value):
+            raise self.error(obj, value)
+        return value


### PR DESCRIPTION
* Refactors the synchronizer to allow for custom, remote "kernel fetching". 
    * By default, it uses the `KernelManager.list_kernels` method to fetch kernels. While this works for kernel/enterprise gateway, this isn't ideal for custom kernel services, since the kernel model in Jupyter Server might not match the model returned by the remote service.  	
* Allows for custom kernel record and kernel manager types.
	* This allows custom kernel record types to pull matching information from customer kernel managers.
	* By default, it works with KG/EG and Jupyter Server out-of-the-box. 
* Adds a handler to the server extension to enable "client-driven" synchronization.
