### PR TITLE
Automated Changelog Entry for 0.0.2 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
-## 0.0.1
+## 0.0.2
+
+([Full Changelog](https://github.com/jupyter-server/synchronizer/compare/v0.0.1...d48b159af0572834188a15a2501f5f26bae9644a))
+
+### Enhancements made
+
+- Make "kernel fetching" configurable and client-driven [#4](https://github.com/jupyter-server/synchronizer/pull/4) ([@Zsailer](https://github.com/Zsailer))
+
+### Maintenance and upkeep improvements
+
+- [pre-commit.ci] pre-commit autoupdate [#3](https://github.com/jupyter-server/synchronizer/pull/3) ([@pre-commit-ci](https://github.com/pre-commit-ci))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/synchronizer/graphs/contributors?from=2022-04-05&to=2022-04-11&type=c))
+
+[@pre-commit-ci](https://github.com/search?q=repo%3Ajupyter-server%2Fsynchronizer+involves%3Apre-commit-ci+updated%3A2022-04-05..2022-04-11&type=Issues) | [@Zsailer](https://github.com/search?q=repo%3Ajupyter-server%2Fsynchronizer+involves%3AZsailer+updated%3A2022-04-05..2022-04-11&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->
+
+## 0.0.1


### PR DESCRIPTION
Automated Changelog Entry for 0.0.2 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/synchronizer  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.0.1 |