### PR TITLE
Make Synchronizer work with Jupyter Kernel Gateways out-of-the-box

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ recursive-include tests *
 # Documentation
 graft docs
 exclude docs/\#*
+exclude Makefile
 
 # docs subdirs we want to skip
 prune docs/build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: kg lab kill
+
+kg:
+	jupyter kernelgateway \
+		--port 9999 \
+		--JupyterWebsocketPersonality.list_kernels=True
+
+lab:
+	jupyter lab \
+		--gateway-url=http://127.0.0.1:9999 \
+		--SessionManager.database_filepath=jupyter-database.db \
+		--SynchronizerExtension.database_filepath=jupyter-database.db \
+		--SynchronizerExtension.autosync=True \
+		--SynchronizerExtension.log_level=DEBUG
+
+teardown:
+	kill -9 $$(echo $$(pgrep -lf jupyter-lab) | awk '{print $$1;}')

--- a/README.md
+++ b/README.md
@@ -27,3 +27,45 @@ jupyter server --SynchronizerExtension.autosync=True
 ```
 
 Otherwise, you can trigger the synchronization making a `POST` request to the `/api/sync` endpoint.
+
+## Example
+
+Below is a example of running the synchronizer with Jupyter Server talking to a Jupyter Kernel Gateway as its "remote" kernel service provider.
+
+First, start the Kernel Gateway. You'll need to enable the `list_kernels` method. In the example, we are assuming the Kernel Gateway is _not_ multi-tenant; i.e. there is a single KG for a single Jupyter Server. We'll set the port to `9999` to free up `8888` for our Jupyter Server.
+
+```
+jupyter kernelgateway \
+    --port 9999 \
+    --JupyterWebsocketPersonality.list_kernels=True
+```
+
+Second, start the Jupyter Server and point it at the Kernel Gateway. Note that we set a `database_filepath` trait in both the `SessionManager` and `SynchronizerExtension` (these paths don't need to be the same). The Synchronize relies on saving/storing of information about Jupyter kernels and sessions in a persistent database. This information is necessary to rehydrate and synchronize.
+
+We'll enable the "autosync" feature to periodically synchronize the server.
+
+```
+jupyter lab \
+    --gateway-url=http://127.0.0.1:9999 \
+    --SessionManager.database_filepath=jupyter-database.db \
+    --SynchronizerExtension.database_filepath=jupyter-database.db \
+    --SynchronizerExtension.autosync=True \
+    --SynchronizerExtension.log_level=DEBUG
+```
+
+Now, let's kill that server:
+
+```
+kill -9 $(echo $(pgrep -lf jupyter-lab) | awk '{print $1;}')
+```
+
+And restart it to see if the kernels rehydrate and begin synchronizing again.
+
+```
+jupyter lab \
+    --gateway-url=http://127.0.0.1:9999 \
+    --SessionManager.database_filepath=jupyter-database.db \
+    --SynchronizerExtension.database_filepath=jupyter-database.db \
+    --SynchronizerExtension.autosync=True \
+    --SynchronizerExtension.log_level=DEBUG
+```

--- a/jupyter_server_synchronizer/gateway.py
+++ b/jupyter_server_synchronizer/gateway.py
@@ -1,0 +1,13 @@
+from jupyter_server.gateway.gateway_client import gateway_request
+from tornado.escape import json_decode
+
+
+async def fetch_gateway_kernels(synchronizer):
+    """Fetch running kernels from a Kernel/Enterprise Gateway."""
+    mkm = synchronizer.multi_kernel_manager
+    response = await gateway_request(mkm.kernels_url, method="GET")
+    kernels = json_decode(response.body)
+    # Hydrate kernelmanager for all remote kernels
+    for k in kernels:
+        kernel = synchronizer.kernel_record_class(kernel_id=k["id"], alive=True)
+        synchronizer._kernel_records.update(kernel)


### PR DESCRIPTION
Adds a default `fetch_running_kernels` method that works with Jupyter Kernel/Enterprise Gateway.

Also adds an example, demo, and Makefile for trying out the extension.