### PR TITLE
Add relevant kernel name to persistent kernel storage for rehydration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,9 @@ kg:
 lab:
 	jupyter lab \
 		--gateway-url=http://127.0.0.1:9999 \
-		--SessionManager.database_filepath=jupyter-database.db \
-		--SynchronizerExtension.database_filepath=jupyter-database.db \
-		--SynchronizerExtension.autosync=True \
-		--SynchronizerExtension.log_level=DEBUG
+		--ServerApp.session_manager_class='jupyter_server_synchronizer.SynchronizerSessionManager' \
+		--SynchronizerSessionManager.database_filepath=jupyter-database.db \
+		--ServerApp.log_level=DEBUG
 
 teardown:
 	kill -9 $$(echo $$(pgrep -lf jupyter-lab) | awk '{print $$1;}')

--- a/jupyter_server_synchronizer/gateway.py
+++ b/jupyter_server_synchronizer/gateway.py
@@ -9,5 +9,7 @@ async def fetch_gateway_kernels(synchronizer):
     kernels = json_decode(response.body)
     # Hydrate kernelmanager for all remote kernels
     for k in kernels:
-        kernel = synchronizer.kernel_record_class(kernel_id=k["id"], kernel_name=k["name"], alive=True)
+        kernel = synchronizer.kernel_record_class(
+            kernel_id=k["id"], kernel_name=k["name"], alive=True
+        )
         synchronizer._kernel_records.update(kernel)

--- a/jupyter_server_synchronizer/gateway.py
+++ b/jupyter_server_synchronizer/gateway.py
@@ -9,5 +9,5 @@ async def fetch_gateway_kernels(synchronizer):
     kernels = json_decode(response.body)
     # Hydrate kernelmanager for all remote kernels
     for k in kernels:
-        kernel = synchronizer.kernel_record_class(kernel_id=k["id"], alive=True)
+        kernel = synchronizer.kernel_record_class(kernel_id=k["id"], kernel_name=k["name"], alive=True)
         synchronizer._kernel_records.update(kernel)

--- a/jupyter_server_synchronizer/kernel_db.py
+++ b/jupyter_server_synchronizer/kernel_db.py
@@ -135,7 +135,7 @@ class KernelTable(Configurable):
         self.query("DELETE FROM {table} WHERE {0}=?", **identifier)
 
     def row_to_model(self, row: sqlite3.Row) -> KernelRecord:
-        items = {field: row[field] for field in self.kernel_record_class.fields()}
+        items = {field: row[field] for field in self._table_columns}
         return self.kernel_record_class(**items)  # type:ignore[no-any-return]
 
     def list(self) -> List[KernelRecord]:

--- a/jupyter_server_synchronizer/kernel_records.py
+++ b/jupyter_server_synchronizer/kernel_records.py
@@ -25,9 +25,14 @@ class KernelRecord:
     # A Kernel record should have at least one field
     # that ends with `_id` in its keyname.
     kernel_id: Union[None, str] = None
+    kernel_name: Union[None, str] = None
     alive: Union[None, bool] = None
     recorded: Union[None, bool] = None
     managed: Union[None, bool] = None
+
+    @classmethod
+    def fields(cls):
+        return fields(cls)
 
     @classmethod
     def from_manager(cls, manager: KernelManager) -> "KernelRecord":
@@ -37,6 +42,7 @@ class KernelRecord:
         # and make the values match.
         for field in cls.get_identifier_fields():
             setattr(record, field, getattr(manager, field, None))
+        record.kernel_name = manager.kernel_name
         record.managed = True
         return record
 
@@ -65,6 +71,15 @@ class KernelRecord:
             if val is not None:
                 identifiers[id] = val
         return identifiers
+
+    def get_active_fields(self):
+        """Get a list of all fields that are not None"""
+        items = {}
+        for field in fields(self):
+            value = getattr(self, field.name)
+            if value:
+                fields[field.name] = value
+        return items
 
     def __eq__(self, other: object) -> bool:
         """Two kernel records are equivalent if *any* of their

--- a/jupyter_server_synchronizer/kernel_records.py
+++ b/jupyter_server_synchronizer/kernel_records.py
@@ -32,7 +32,7 @@ class KernelRecord:
 
     @classmethod
     def fields(cls):
-        return fields(cls)
+        return [f.name for f in fields(cls)]
 
     @classmethod
     def from_manager(cls, manager: KernelManager) -> "KernelRecord":
@@ -78,7 +78,7 @@ class KernelRecord:
         for field in fields(self):
             value = getattr(self, field.name)
             if value:
-                fields[field.name] = value
+                items[field.name] = value
         return items
 
     def __eq__(self, other: object) -> bool:

--- a/jupyter_server_synchronizer/manager.py
+++ b/jupyter_server_synchronizer/manager.py
@@ -119,7 +119,7 @@ class SynchronizerSessionManager(SessionManager):
                 if not k.kernel_id:
                     kernel_id = str(uuid.uuid4())
                     k.kernel_id = kernel_id
-                identifiers = k.get_active_identifiers()
+                identifiers = k.get_active_fields()
                 await self.kernel_manager.start_kernel(**identifiers)
                 k.managed = True
 

--- a/jupyter_server_synchronizer/manager.py
+++ b/jupyter_server_synchronizer/manager.py
@@ -119,8 +119,8 @@ class SynchronizerSessionManager(SessionManager):
                 if not k.kernel_id:
                     kernel_id = str(uuid.uuid4())
                     k.kernel_id = kernel_id
-                identifiers = k.get_active_fields()
-                await self.kernel_manager.start_kernel(**identifiers)
+                kwargs = k.get_active_fields()
+                await self.kernel_manager.start_kernel(**kwargs)
                 k.managed = True
 
     async def delete_stale_sessions(self):

--- a/tests/test_kernel_db.py
+++ b/tests/test_kernel_db.py
@@ -28,11 +28,11 @@ def test_cursor(jp_environ):
 def test_save_kernelrecord(jp_environ):
     kernel_id = "test-kernel-id"
     table = KernelTable()
-    record = KernelRecord(kernel_id=kernel_id)
+    record = KernelRecord(kernel_id=kernel_id, kernel_name="python3")
     table.save(record)
     found_record = table.get(kernel_id=kernel_id)
     assert hasattr(found_record, "kernel_id") and found_record.kernel_id == kernel_id
-
+    assert hasattr(found_record, "kernel_name") and found_record.kernel_name == "python3"
 
 def test_delete_kernelrecord(jp_environ):
     kernel_id = "test-kernel-id"

--- a/tests/test_kernel_db.py
+++ b/tests/test_kernel_db.py
@@ -34,6 +34,7 @@ def test_save_kernelrecord(jp_environ):
     assert hasattr(found_record, "kernel_id") and found_record.kernel_id == kernel_id
     assert hasattr(found_record, "kernel_name") and found_record.kernel_name == "python3"
 
+
 def test_delete_kernelrecord(jp_environ):
     kernel_id = "test-kernel-id"
     table = KernelTable()


### PR DESCRIPTION
This is needed to rehydrate a kernel manager with the proper kernel spec.