### PR TITLE
If synchronizer fails, warn gracefully and continue

### DIFF
--- a/jupyter_server_synchronizer/manager.py
+++ b/jupyter_server_synchronizer/manager.py
@@ -230,7 +230,7 @@ class SynchronizerSessionManager(SessionManager):
             await self.sync_managers()
         except Exception as e:
             self.log.error(e)
-        out = await SessionManager.list_sessions(self)
+        out = await super().list_sessions(self)
         return out
 
     async def _regular_syncing(self, interval=5.0):


### PR DESCRIPTION
When the synchronizer failed, it would cause the whole session API to fail. Instead, we should raise an error and continue on with the session list.