### PR TITLE
Automated Changelog Entry for 0.0.7 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.0.7
+
+([Full Changelog](https://github.com/jupyter-server/synchronizer/compare/v0.0.6...720b7df76570a89d6391d4c103072f748cda1c47))
+
+### Bugs fixed
+
+- If synchronizer fails, warn gracefully and continue [#22](https://github.com/jupyter-server/synchronizer/pull/22) ([@Zsailer](https://github.com/Zsailer))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/synchronizer/graphs/contributors?from=2022-05-05&to=2022-05-06&type=c))
+
+[@Zsailer](https://github.com/search?q=repo%3Ajupyter-server%2Fsynchronizer+involves%3AZsailer+updated%3A2022-05-05..2022-05-06&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.0.6
 
 ([Full Changelog](https://github.com/jupyter-server/synchronizer/compare/v0.0.5...11f5c8daa9501f39898a9a608014566db5075e44))
@@ -17,8 +33,6 @@ All notable changes to this project will be documented in this file.
 ([GitHub contributors page for this release](https://github.com/jupyter-server/synchronizer/graphs/contributors?from=2022-05-05&to=2022-05-05&type=c))
 
 [@Zsailer](https://github.com/search?q=repo%3Ajupyter-server%2Fsynchronizer+involves%3AZsailer+updated%3A2022-05-05..2022-05-05&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.0.5
 


### PR DESCRIPTION
Automated Changelog Entry for 0.0.7 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/synchronizer  |
| Branch  | main  |
| Version Spec | 0.0.7 |
| Since | v0.0.6 |