### PR TITLE
Add missing list_sessions method

### DIFF
--- a/jupyter_server_synchronizer/manager.py
+++ b/jupyter_server_synchronizer/manager.py
@@ -225,6 +225,7 @@ class SynchronizerSessionManager(SessionManager):
         self.log.debug("Synchronizing kernel sessions.")
         await self.sync_sessions()
 
+    async def list_sessions(self):
         # Run the synchronizer loop
         try:
             await self.sync_managers()


### PR DESCRIPTION
#22 introduced a bug by accidentally deleting the `list_sessions` method.