### PR TITLE
rm the redundant argument for list_sessions()

### DIFF
--- a/jupyter_server_synchronizer/manager.py
+++ b/jupyter_server_synchronizer/manager.py
@@ -231,7 +231,7 @@ class SynchronizerSessionManager(SessionManager):
             await self.sync_managers()
         except Exception as e:
             self.log.error(e)
-        out = await super().list_sessions(self)
+        out = await super().list_sessions()
         return out
 
     async def _regular_syncing(self, interval=5.0):


### PR DESCRIPTION
fix the issue: https://github.com/jupyter-server/synchronizer/issues/41